### PR TITLE
Vec: fix init

### DIFF
--- a/src/FSharp.Core.Extensions/Vec.fs
+++ b/src/FSharp.Core.Extensions/Vec.fs
@@ -583,7 +583,7 @@ module Vec =
     /// which takes an index (0-based) from which an element will be created.
     [<CompiledName("Init")>]
     let init (size: int) (fn: int -> 'a): Vec<'a> =
-        let t = empty.AsBuilder()
+        let mutable t = empty.AsBuilder()
         for i = 0 to size - 1 do
             t.Add (fn i)
         t.ToImmutable()

--- a/tests/FSharp.Core.Extensions.Tests/VecTests.fs
+++ b/tests/FSharp.Core.Extensions.Tests/VecTests.fs
@@ -135,4 +135,8 @@ let tests =
             let expected = Array.init 100 (fun i -> i+10)
             Expect.equal actual expected "Vec.append should be able to append many elements"
             
+        testCase "should init a vector with specified size" <| fun _ ->
+            let v = Vec.init 10 id
+            Expect.equal v.Count 10 "Vec.init should initialize with specified size"
+
     ]


### PR DESCRIPTION
Currently, Vec.init always results in a vector with size 0. The test case should reproduce this. This fix it.
This got me by surprise, I didn't know a mutable was necessary there.