### PR TITLE
fix: AsyncSeq.mapParallel can miss elements

### DIFF
--- a/tests/FSharp.Core.Extensions.Tests/AsyncSeqTests.fs
+++ b/tests/FSharp.Core.Extensions.Tests/AsyncSeqTests.fs
@@ -325,6 +325,16 @@ let tests =
                 |> List.ofSeq
             Expect.containsAll actual [|2..41|] "result should contain necessary elements"
             
+        testCase "mapParallel should see all elements" <| fun _ ->
+            let actual =
+                [|1.. 40|]
+                |> AsyncSeq.ofSeq
+                |> AsyncSeq.mapParallel 4 (fun i -> vtask { return 1 })
+                |> AsyncSeq.fold (fun s i -> vtask { return s + i }) 0
+                |> eval
+
+            Expect.equal actual 40 "result should have seen all elements"
+
         testCase "repeat should be composable into range sequence" <| fun _ ->
             let actual =
                 AsyncSeq.repeat 1


### PR DESCRIPTION
I noticed some missing elements when switching from map to mapParallel in code like:

```fs
let! results =
  groups
  |> AsyncSeq.ofSeq
  |> AsyncSeq.mapParallel 8 ingestRecord
  // |> AsyncSeq.mapAsync ingestRecord
  |> AsyncSeq.fold collectResults MessageIngestionResult.Zero
```

Fix was: wrapped the write operation in its own loop to prevent a fail on TryWrite from going to the top of the read loop after waiting to retry in the `MapParallelEnumerator`'s workers

