### PR TITLE
fix: AsyncSeq choose and filter always produce empty sequences 

### DIFF
--- a/src/FSharp.Core.Extensions/AsyncSeq.fs
+++ b/src/FSharp.Core.Extensions/AsyncSeq.fs
@@ -403,6 +403,7 @@ module AsyncSeq =
                     member __.DisposeAsync() = inner.DisposeAsync()
                     member __.MoveNextAsync() = vtask {
                         let! hasNext = inner.MoveNextAsync()
+                        let mutable innerHasMore = hasNext
                         let mutable cont = hasNext
                         while cont do
                             let! result = f inner.Current
@@ -412,8 +413,9 @@ module AsyncSeq =
                                 cont <- false
                             | None ->
                                 let! hasNext = inner.MoveNextAsync()
+                                innerHasMore <- hasNext
                                 cont <- hasNext
-                        return cont && Option.isSome current      
+                        return innerHasMore      
                     } }}
     
     /// Returns an async sequence which filters out the input async sequence elements,

--- a/tests/FSharp.Core.Extensions.Tests/AsyncSeqTests.fs
+++ b/tests/FSharp.Core.Extensions.Tests/AsyncSeqTests.fs
@@ -148,9 +148,14 @@ let tests =
                 |> AsyncSeq.collect
                 |> eval
             
-            for i in actual do
-                Expect.isTrue (i % 2 <> 0) "choose should apply both mapping and filter"
-                
+            let expected =
+                input
+                |> Array.choose (fun e ->
+                    if e % 2 = 0 then Some (e+1)
+                    else None)
+
+            Expect.equal actual expected "AsyncSeq.choose should match Array.choose over same input and chooser"
+
         testProperty "filter should only pick correct elements" <| fun (input: int[]) ->
             let actual =
                 input
@@ -158,9 +163,10 @@ let tests =
                 |> AsyncSeq.filter (fun e -> e % 2 = 0)
                 |> AsyncSeq.collect
                 |> eval
-            
-            for i in actual do
-                Expect.isTrue (i % 2 = 0) "filter should not pass incorrect elements"
+
+            let expected = input |> Array.filter (fun e -> e % 2 = 0)
+
+            Expect.equal actual expected "AsyncSeq.filter should match Array.filter over same input and predicate"
                 
         testProperty "bind should execute all sub-sequences until completion" <| fun (input: int[][]) ->
             let actual =


### PR DESCRIPTION
First commit changes the existing tests to fail on the current implementation by comparing the AsyncSeq filter/choose results with the Array filter/choose results over the same input.

Second commit fixes this by keeping track of the inner AsyncSeq having more elements whenever MoveNextAsync was called separately from the loop's exit condition