### PR TITLE
Fix out of range issues with GetEnumerator

### DIFF
--- a/src/FSharp.Core.Extensions/Vec.fs
+++ b/src/FSharp.Core.Extensions/Vec.fs
@@ -455,11 +455,11 @@ and [<Sealed>] Vec<'a> internal(count: int, shift: int, root: VecNode<'a>, tail:
                     if i < this.Count then
                         if isNull array then array <- this.FindArrayForIndex(i)
                         else
-                            if i - offset = VecConst.capacity then
-                                array <- this.FindArrayForIndex(i)
+                            if i - offset = VecConst.capacity - 1 then
+                                array <- this.FindArrayForIndex(i + 1)
                                 offset <- offset + VecConst.capacity
                             index <- i + 1
-                        true
+                        index &&& VecConst.mask < array.Length
                     else false }
         member this.GetEnumerator(): System.Collections.IEnumerator =
             upcast (this :> IEnumerable<'a>).GetEnumerator()

--- a/tests/FSharp.Core.Extensions.Tests/VecTests.fs
+++ b/tests/FSharp.Core.Extensions.Tests/VecTests.fs
@@ -139,4 +139,15 @@ let tests =
             let v = Vec.init 10 id
             Expect.equal v.Count 10 "Vec.init should initialize with specified size"
 
+        testCase "should be able to enumerate collection of elements of length under 32" <| fun _ ->
+            let v = Vec.ofArray [|1..5|]
+            let actual = seq { for i in v do yield i} |> Seq.toArray
+            let expected = [|1..5|]
+            Expect.equal actual expected "Vec.IEnumerable should be able to enumerate collection of elements of length under 32"
+
+        testCase "should be able to enumerate collection of elements of length over 32" <| fun _ ->
+            let v = Vec.ofArray [|1..100|]
+            let actual = seq { for i in v do yield i} |> Seq.toArray
+            let expected = [|1..100|]
+            Expect.equal actual expected "Vec.IEnumerable should be able to enumerate collection of elements of length over 32"
     ]


### PR DESCRIPTION
Fix the following exception: 

```fsharp
let vec = Vec.ofArray [|1; 2; 3;|]
let s = seq { for i in vec do yield i }
s |> Seq.iter (printfn "%A")
```

```shell
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at <StartupCode$Domain-Pls-FsUtil>.$Vec.System-Collections-Generic-IEnumerable<'a>-GetEnumerator@449.System.Collections.Generic.IEnumerator<'a>.get_Current() in /Users/swoorup.joshi/work/gp-pls-fsutil/src/Domain.Pls.FsUtil/Vec.fs:line 454
```